### PR TITLE
Use the new build env on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ gemfile:
   - gemfiles/activesupport_3.2.gemfile
   - gemfiles/activesupport_4.0.gemfile
 
-sudo:false
+sudo: false
 
 matrix:
   allow_failures:


### PR DESCRIPTION
faster vms, more ram, more cpu, faster vm boot times

docs coming soon

also reduced the versions of 2.1.x it was tested against as we highly recommend only testing on the latest as other versions are just patch releases.
